### PR TITLE
DXS-95: Users want to run a Policy Scan ONLY on PR and ONLY on a single selected branch

### DIFF
--- a/veracode.yml
+++ b/veracode.yml
@@ -22,7 +22,7 @@ veracode_static_scan:
   # By selecting a branch here - Veracode will save your last scan result
   # As an App Profile - given the current name of your scanned repo
   # Use 'none' if you would not like any scans saved to the platform
-  analysis_branch: "default"
+  analysis_branch: default_branch
   #If the break_build_policy_findings is set to true, the build will break if the pipeline scan finds any policy violations.      
   break_build_policy_findings: true
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete in time or with an error.

--- a/veracode.yml
+++ b/veracode.yml
@@ -1,9 +1,12 @@
-veracode_sast_pipeline_scan:
+veracode_static_scan:
   # Please only specify trigger:true for either push event or 
   # pull request event. Specifying both will only execute push event.
   # Leaving them both false means this will never run
   push:
     trigger: true
+    # Please only specify either branches_to_run or branches_to_exclude
+    # Entering both will only execute branches_to_run
+    # Leaving them both blank means this will never run
     branches_to_run:
       - default_branch
     branches_to_exclude:
@@ -15,6 +18,11 @@ veracode_sast_pipeline_scan:
       - synchronize
     target_branch:
       - default_branch 
+  # What branch would you like to use for platform analysis 
+  # By selecting a branch here - Veracode will save your last scan result
+  # As an App Profile - given the current name of your scanned repo
+  # Use 'none' if you would not like any scans saved to the platform
+  analysis_branch: "default"
   #If the break_build_policy_findings is set to true, the build will break if the pipeline scan finds any policy violations.      
   break_build_policy_findings: true
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete in time or with an error.
@@ -24,32 +32,6 @@ veracode_sast_pipeline_scan:
   policy: 'Veracode Recommended Medium + SCA'
   compile_locally: false
   local_compilation_workflow: na
-
-veracode_sast_policy_scan:
-  # Please only specify trigger:true for either push event or 
-  # pull request event. Specifying both will only execute push event.
-  # Leaving them both false means this will never run
-  push:
-    trigger: true
-    branches_to_run:
-      - default_branch
-    branches_to_exclude:
-  pull_request:
-    trigger: true
-    action:
-      - opened
-      - synchronize
-    target_branch:
-      - default_branch
-  #If the break_build_policy_findings is set to true, the build will break if the pipeline scan finds any policy violations.      
-  break_build_policy_findings: true
-  #If the break_build_on_error is set to true, the build will break if the scan failed to complete in time or with an error.
-  break_build_on_error: true
-  #If the break_build_on_policy_error is set to true, this is the error message that will be displayed if the pipeline scan fails to complete in time or with an error.
-  error_message: "Veracode SAST scan faced a problem. Please contact your Veracode administrator for more information. If you are a Veracode administrator, please contact Veracode support."
-  policy: 'Veracode Recommended Medium + SCA'
-  compile_locally: false
-  local_compilation_workflow: veracode-build
 
 veracode_sca_scan:   
   # Please only specify trigger:true for either push event or 


### PR DESCRIPTION
As a part of [DXS-95](https://veracode.atlassian.net/browse/DXS-95) story, we have updated the veracode.yml file.

Please refer : https://github.com/repo-scan-demo/veracode/blob/mtawadrousv-patch-1/veracode.yml