### PR TITLE
Spelling Error on the Actions Run for Policy scan

### DIFF
--- a/.github/workflows/binary-ready-veracode-sast-policy-scan.yml
+++ b/.github/workflows/binary-ready-veracode-sast-policy-scan.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           artifact_file=$(ls -1 ./veracode-artifact | head -n 1)
           echo "veracode_artifact=$artifact_file" >> $GITHUB_ENV
-      - name: Veracoe Upload and Scan Action Step
+      - name: Veracode Upload and Scan Action Step
         uses: veracode/uploadandscan-action@main
         id: upload_and_scan
         with:


### PR DESCRIPTION
Spelling error on Veracoe -> Veracode during the actions step for policy scan.