### PR TITLE
Fix/core 5475/split go modules

### DIFF
--- a/.github/workflows/veracode-build-go.yml
+++ b/.github/workflows/veracode-build-go.yml
@@ -14,7 +14,47 @@ on:
         type: string
 
 jobs:
+  resolve-modules:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          token: ${{ inputs.token }}
+          depth: 0
+      - name: Run modules change check
+        id: set-matrix
+        shell: bash
+        run: |
+          directory=.
+          echo "Resolving modules in $(pwd)"
+
+          # Initialize PATHS as an empty string
+          PATHS=""
+
+          # Recursively find all directories with a go.mod file
+          while IFS= read -r -d '' mod_file; do
+            directory=$(dirname "$mod_file")
+            echo $directory
+            # Add the directory to PATHS if the condition is true
+            PATHS+="{\"workdir\":\"$(dirname "$mod_file")\"},"
+          done < <(find "$directory" -type f -name go.mod -print0)
+
+          # Check if PATHS is not empty before creating the matrix
+          if [ -n "$PATHS" ]; then
+            echo "No directories found."
+          fi
+          echo "matrix={\"include\":[${PATHS%,}]}" 
+          echo "matrix={\"include\":[${PATHS%,}]}" >> "$GITHUB_OUTPUT"
   build:
+    needs: resolve-modules
+    if: ${{ needs.resolve-modules.outputs.matrix != '{"include":[]}' }}
+    strategy:
+      matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +64,7 @@ jobs:
           token: ${{ inputs.token }}
       - name: Check if go.mod exists
         id: check-go-mod
+        working-directory: ${{ matrix.workdir }}
         run: |
           if [ -f "go.mod" ]; then
             echo "go.mod exists"
@@ -39,6 +80,11 @@ jobs:
           go-version: 'stable'
           cache: false
 
+      - name: Set Git to ssh
+        shell: bash
+        run: |
+          git config --global url."https://${{ inputs.token }}@github.com/".insteadOf "https://github.com/"
+
       - name: Set Go Envs
         shell: bash
         run: go env -w GOPRIVATE=github.com/smarterly/\*
@@ -49,6 +95,7 @@ jobs:
           export PATH="$GOPATH/bin:$PATH" && go install github.com/relaxnow/vcgopkg@latest
 
       - name: Initialize and tidy go mod
+        working-directory: ${{ matrix.workdir }}
         run: |
           if [[ "${{ steps.check-go-mod.outputs.go_mod_exists }}" == "false" ]]; then
             go mod init github.com/${{ inputs.repository }}
@@ -56,9 +103,11 @@ jobs:
           fi
 
       - name: Run vcgopkg
+        working-directory: ${{ matrix.workdir }}
         run: vcgopkg
         
       - uses: actions/upload-artifact@v3
         with:
           name: veracode-artifact
-          path: ./veracode
+          path: ${{ matrix.workdir }}/veracode
+

--- a/.github/workflows/veracode-iac-secrets-scan.yml
+++ b/.github/workflows/veracode-iac-secrets-scan.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.client_payload.sha }}
           token: ${{ github.event.client_payload.token }}
       - name: Run Veracode IaC/Secrets Scanning
-        uses: veracode/container_iac_secrets_scanning@v1.0.0
+        uses: veracode/container_iac_secrets_scanning@v1.0.1
         with:
             vid: ${{ secrets.VERACODE_API_ID }}
             vkey: ${{ secrets.VERACODE_API_KEY }}

--- a/veracode.yml
+++ b/veracode.yml
@@ -11,7 +11,7 @@ veracode_static_scan:
       - '*'
     branches_to_exclude:
   pull_request:
-    trigger: true
+    trigger: false
     action:
       - opened
       - synchronize
@@ -37,12 +37,12 @@ veracode_sca_scan:
   # pull request event. Specifying both will only execute push event.
   # Leaving them both false means this will never run
   push:
-    trigger: true
+    trigger: false
     branches_to_run:
       - '*'
     branches_to_exclude:
   pull_request:
-    trigger: true
+    trigger: false
     action:
       - opened
       - synchronize
@@ -60,12 +60,12 @@ veracode_iac_secrets_scan:
   # pull request event. Specifying both will only execute push event.
   # Leaving them both false means this will never run
   push:
-    trigger: true
+    trigger: false
     branches_to_run:
       - '*'
     branches_to_exclude:
   pull_request:
-    trigger: true
+    trigger: false
     action:
       - opened
       - synchronize

--- a/veracode.yml
+++ b/veracode.yml
@@ -23,7 +23,7 @@ veracode_static_scan:
   # Use 'none' if you would not like any scans saved to the platform
   analysis_branch: default_branch
   #If the break_build_policy_findings is set to true, the build will break if the pipeline scan finds any policy violations.      
-  break_build_policy_findings: true
+  break_build_policy_findings: false
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete in time or with an error.
   break_build_on_error: true
   #If the break_build_on_policy_error is set to true, this is the error message that will be displayed if the pipeline scan fails to complete in time or with an error.
@@ -49,7 +49,7 @@ veracode_sca_scan:
     target_branch:
       - default_branch
   #If the break_build_policy_findings is set to true, the build will break if the SCA scan finds any policy violations.      
-  break_build_policy_findings: true
+  break_build_policy_findings: false
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete, no libraries found, no build system found or on any other error.
   break_build_on_error: true
   #If the break_build_on_policy_error is set to true, this is the error message that will be displayed if the SCA scan fails to complete, no libraries found, no build system found or on any other error.
@@ -72,7 +72,7 @@ veracode_iac_secrets_scan:
     target_branch:
       - default_branch
   #If the break_build_policy_findings is set to true, the build will break if the IaC/Secrets scan finds any policy violations.      
-  break_build_policy_findings: true
+  break_build_policy_findings: false
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete, no libraries found or on any other error.
   break_build_on_error: true
   #If the break_build_on_policy_error is set to true, this is the error message that will be displayed if the IaC/Secrets scan fails to complete, no libraries found or on any other error.

--- a/veracode.yml
+++ b/veracode.yml
@@ -3,7 +3,7 @@ veracode_static_scan:
   # pull request event. Specifying both will only execute push event.
   # Leaving them both false means this will never run
   push:
-    trigger: true
+    trigger: false
     # Please only specify either branches_to_run or branches_to_exclude
     # Entering both will only execute branches_to_run
     # Leaving them both blank means this will never run
@@ -11,21 +11,21 @@ veracode_static_scan:
       - '*'
     branches_to_exclude:
   pull_request:
-    trigger: false
+    trigger: true
     action:
       - opened
       - synchronize
     target_branch:
-      - default_branch 
+      - default_branch
   # What branch would you like to use for platform analysis 
   # By selecting a branch here - Veracode will save your last scan result
   # As an App Profile - given the current name of your scanned repo
   # Use 'none' if you would not like any scans saved to the platform
-  analysis_branch: ENTER_BRANCH_NAME_HERE
+  analysis_branch: default_branch
   #If the break_build_policy_findings is set to true, the build will break if the pipeline scan finds any policy violations.      
   break_build_policy_findings: true
   #If the break_build_on_error is set to true, the build will break if the scan failed to complete in time or with an error.
-  break_build_on_error: false
+  break_build_on_error: true
   #If the break_build_on_policy_error is set to true, this is the error message that will be displayed if the pipeline scan fails to complete in time or with an error.
   error_message: "Veracode SAST scan faced a problem. Please contact your Veracode administrator for more information. If you are a Veracode administrator, please contact Veracode support."
   policy: 'Veracode Recommended Medium + SCA'
@@ -42,7 +42,7 @@ veracode_sca_scan:
       - '*'
     branches_to_exclude:
   pull_request:
-    trigger: false
+    trigger: true
     action:
       - opened
       - synchronize


### PR DESCRIPTION
Veracode does not support multi module repos, this PR splits up the repo to be processed via veracode. 

From veracode docs:
```
Upload requirements
An upload must only contain one Go module.
You must split a multi-module project into separate uploads.
The go.mod file for a module must be in the top-level directory of your archive.

Veracode cannot analyze a Go module or package without a main() function.
```
https://docs.veracode.com/r/compilation_go


Still need to solve the `Veracode cannot analyze a Go module or package without a main() function.` but we could modify to look for a main, if it does not see one then skips. This would then only scan our deployment units