### PR TITLE
ci: update GitHub Actions dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
This PR introduces a dependabot configuration to keep the GitHub Action dependencies up-to-date