### PR TITLE
Enable analysis to be saved  in Veracode platform.

### DIFF
--- a/veracode.yml
+++ b/veracode.yml
@@ -17,7 +17,7 @@ veracode_static_scan:
   # If the analysis_on_platform is set to true,
   # Veracode will save your last scan result, on the default branch, as an application profile with the same name as your scanned repository on the Veracode platform. 
   # If the analysis_on_platform is set to false, scan results will not be saved to the Veracode platform.
-  analysis_on_platform: false
+  analysis_on_platform: true
   # If break_build_policy_findings is set to true, the build will break when findings violate the policy.
   break_build_policy_findings: true
   # If break_build_invalid_policy is set to true, the build will break when the policy name is invalid.


### PR DESCRIPTION
If false, no scans are submitted to the Veracode Platform. If true, scans from the analysis_branch are submitted to the Platform, creating an [application profile](https://docs.veracode.com/r/request_profile) that has the repository's name.