### PR TITLE
REPO-723 add logic to seperate scans names

### DIFF
--- a/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
+++ b/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Verify Veracode API credentials
         id: verify_api_creds
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validateVeracodeApiCreds
           token: ${{ github.event.client_payload.token }}
@@ -43,7 +43,7 @@ jobs:
       - name: Verify Policy name
         id: verify_policy_name
         if: success()
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validatePolicyName
           token: ${{ github.event.client_payload.token }}
@@ -83,7 +83,7 @@ jobs:
       - name: Veracode Pipeline Results
         if: always()
         id: prepare-results
-        uses: Veracode/github-actions-integration-helper@v0.1.2
+        uses: Veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'preparePipelineResults'
           token: ${{ github.event.client_payload.token }}

--- a/.github/workflows/binary-ready-veracode-sast-policy-scan.yml
+++ b/.github/workflows/binary-ready-veracode-sast-policy-scan.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Verify Veracode API credentials
         id: verify_api_creds
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validateVeracodeApiCreds
           token: ${{ github.event.client_payload.token }}
@@ -43,7 +43,7 @@ jobs:
       - name: Verify Policy name
         id: verify_policy_name
         if: success()
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validatePolicyName
           token: ${{ github.event.client_payload.token }}
@@ -88,7 +88,7 @@ jobs:
       - name: Veracode Policy Results
         id: prepare-results
         if: always()
-        uses: Veracode/github-actions-integration-helper@v0.1.2
+        uses: Veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'preparePolicyResults'
           token: ${{ github.event.client_payload.token }}
@@ -107,7 +107,7 @@ jobs:
     if: ${{ github.event.client_payload.user_config.sandbox_scan.execute_remove_sandbox_action && always() }}
     name: Remove Sandbox
     steps:
-      - uses: veracode/github-actions-integration-helper@v0.1.2
+      - uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'removeSandbox'
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.github/workflows/template-register.yaml
+++ b/.github/workflows/template-register.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Register build
       id: register-build
-      uses: veracode/github-actions-integration-helper@v0.1.2
+      uses: veracode/github-actions-integration-helper@v0.1.3
       with:
         action: registerBuild
         token: ${{ github.event.client_payload.token }}

--- a/.github/workflows/veracode-build-artifact-for-scanning.yml
+++ b/.github/workflows/veracode-build-artifact-for-scanning.yml
@@ -18,7 +18,7 @@ on:
   
 jobs:
   build:
-    if: ${{ inputs.event_name == 'java-pipeline-scan' || inputs.event_name == 'java-policy-scan' || inputs.event_name == 'java-sandbox-scan' || inputs.event_name == 'unidentified-lang-pipeline-scan' || inputs.event_name == 'unidentified-lang-policy-scan' || inputs.event_name == 'unidentified-lang-sandbox-scan' }}
+    if: ${{ inputs.event_name == 'java-pipeline-scan' || inputs.event_name == 'java-policy-scan' || inputs.event_name == 'java-sandbox-scan' || inputs.event_name == 'unidentified-lang-pipeline-scan' || inputs.event_name == 'unidentified-lang-policy-scan' || inputs.event_name == 'unidentified-lang-sandbox-scan' || inputs.event_name == 'dot-net-pipeline-scan' || inputs.event_name == 'dot-net-policy-scan' || inputs.event_name == 'dot-net-sandbox-scan'}}
     uses: ./.github/workflows/veracode-default-build.yml
     with:
       repository: ${{ inputs.repository }}
@@ -44,14 +44,6 @@ jobs:
   build-source-code-scan:
     if: ${{ inputs.event_name == 'source-code-pipeline-scan' || inputs.event_name == 'source-code-policy-scan'  || inputs.event_name == 'source-code-sandbox-scan'}}
     uses: ./.github/workflows/veracode-build-source-code.yml
-    with:
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.ref }}
-      token: ${{ inputs.token }}
-      
-  build-dot-net-package:
-    if: ${{ inputs.event_name == 'dot-net-pipeline-scan' || inputs.event_name == 'dot-net-policy-scan'  || inputs.event_name == 'dot-net-sandbox-scan'}}
-    uses: ./.github/workflows/veracode-build-dot-net.yml
     with:
       repository: ${{ inputs.repository }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/veracode-code-analysis.yml
+++ b/.github/workflows/veracode-code-analysis.yml
@@ -38,7 +38,7 @@ jobs:
   register:
     uses: ./.github/workflows/veracode-check-run.yml
     with:
-      check_run_name: ${{ github.workflow }}${{ contains( github.event.action, 'policy') && ' - Policy Scan' || ' - Pipeline Scan' }}
+      check_run_name: ${{ github.workflow }} - ${{ contains( github.event.action, 'policy') && 'Policy' || 'Pipeline' }}
       head_sha: ${{ github.event.client_payload.sha }}
       repositroy_owner: ${{ github.event.client_payload.repository.owner }}
       repositroy_name: ${{ github.event.client_payload.repository.name }}

--- a/.github/workflows/veracode-code-analysis.yml
+++ b/.github/workflows/veracode-code-analysis.yml
@@ -8,7 +8,7 @@ concurrency:
 
 on:
   repository_dispatch:
-    types: 
+    types:
       - java-maven-pipeline-scan
       - java-maven-policy-scan
       - java-gradle-pipeline-scan
@@ -38,7 +38,7 @@ jobs:
   register:
     uses: ./.github/workflows/veracode-check-run.yml
     with:
-      check_run_name: ${{ github.workflow }}
+      check_run_name: ${{ github.workflow }}${{ contains( github.event.action, 'policy') && ' - Policy Scan' || ' - Pipeline Scan' }}
       head_sha: ${{ github.event.client_payload.sha }}
       repositroy_owner: ${{ github.event.client_payload.repository.owner }}
       repositroy_name: ${{ github.event.client_payload.repository.name }}
@@ -63,7 +63,7 @@ jobs:
           appname: ${{ github.event.client_payload.user_config.profile_name }}
           source_repository: ${{ github.event.client_payload.repository.full_name }}
           check_run_id: ${{ needs.register.outputs.run_id }}
-      
+
       - name: Verify Policy name
         id: verify_policy_name
         if: success()
@@ -81,7 +81,7 @@ jobs:
           start_line: ${{ github.event.client_payload.annotationObj.start_line }}
           end_line: ${{ github.event.client_payload.annotationObj.end_line }}
           break_build_invalid_policy: ${{github.event.client_payload.break_build_invalid_policy }}
- 
+
   build:
     needs: validations
     uses: ./.github/workflows/veracode-build-artifact-for-scanning.yml
@@ -114,7 +114,7 @@ jobs:
       filter_mitigated_flaws: ${{ github.event.client_payload.user_config.filter_mitigated_flaws }}
       language: ${{ github.event.client_payload.repository.language }}
     secrets: inherit
-    
+
   policy_scan:
     needs: [build, register]
     if: contains(github.event.action, 'policy')

--- a/.github/workflows/veracode-code-analysis.yml
+++ b/.github/workflows/veracode-code-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Verify Veracode API credentials
         id: verify_api_creds
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validateVeracodeApiCreds
           token: ${{ github.event.client_payload.token }}
@@ -67,7 +67,7 @@ jobs:
       - name: Verify Policy name
         id: verify_policy_name
         if: success()
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validatePolicyName
           token: ${{ github.event.client_payload.token }}

--- a/.github/workflows/veracode-code-analysis.yml
+++ b/.github/workflows/veracode-code-analysis.yml
@@ -38,7 +38,7 @@ jobs:
   register:
     uses: ./.github/workflows/veracode-check-run.yml
     with:
-      check_run_name: ${{ github.workflow }} - ${{ contains( github.event.action, 'policy') && 'Policy' || 'Pipeline' }}
+      check_run_name: ${{ github.workflow }} - ${{ contains(github.event.action, 'policy') && 'Policy' || 'Pipeline' }}
       head_sha: ${{ github.event.client_payload.sha }}
       repositroy_owner: ${{ github.event.client_payload.repository.owner }}
       repositroy_name: ${{ github.event.client_payload.repository.name }}

--- a/.github/workflows/veracode-default-build.yml
+++ b/.github/workflows/veracode-default-build.yml
@@ -54,5 +54,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: veracode-artifact
-        path: /__w/veracode/veracode/veracode-artifact.zip
+        path: /__w/veracode/veracode/veracode-artifacts/*
         if-no-files-found: error

--- a/.github/workflows/veracode-iac-secrets-scan.yml
+++ b/.github/workflows/veracode-iac-secrets-scan.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Verify Veracode API credentials
         id: verify_api_creds
-        uses: veracode/github-actions-integration-helper@v0.1.2
+        uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: validateVeracodeApiCreds
           token: ${{ github.event.client_payload.token }}

--- a/.github/workflows/veracode-pipeline-scan.yml
+++ b/.github/workflows/veracode-pipeline-scan.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Veracode Pipeline Results
         if: always()
         id: prepare-results
-        uses: Veracode/github-actions-integration-helper@v0.1.2
+        uses: Veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'preparePipelineResults'
           token: ${{ inputs.token }}

--- a/.github/workflows/veracode-policy-scan.yml
+++ b/.github/workflows/veracode-policy-scan.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Veracode Policy Results
         id: prepare-results
         if: always()
-        uses: Veracode/github-actions-integration-helper@v0.1.2
+        uses: Veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'preparePolicyResults'
           token: ${{ inputs.token }}
@@ -107,7 +107,7 @@ jobs:
     if: ${{ github.event.client_payload.user_config.sandbox_scan.execute_remove_sandbox_action && always() }}
     name: Remove Sandbox
     steps:
-      - uses: veracode/github-actions-integration-helper@v0.1.2
+      - uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'removeSandbox'
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.github/workflows/veracode-remove-sandbox.yml
+++ b/.github/workflows/veracode-remove-sandbox.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Remove Sandbox
     steps:
-      - uses: veracode/github-actions-integration-helper@v0.1.2
+      - uses: veracode/github-actions-integration-helper@v0.1.3
         with:
           action: 'removeSandbox'
           vid: ${{ secrets.VERACODE_API_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea


### PR DESCRIPTION
### What changed
* Updated the `github-actions-integration` repo so that check run names can differentiate between pipeline and policy scans. 
* Updated the workflow files to use the latest version of the `github-actions-integration-helper`. `v0.1.3` changes will make sure that policy scans will always have the results URL  (scan results on the platform) present when the scan completes. Previously, the results URL would only be present on policy scans that had findings in them. 

PR: https://github.com/veracode/github-actions-integration-helper/pull/9

### Proof that it works: 
![Screenshot 2024-06-19 at 10 41 43 AM](https://github.com/veracode/github-actions-integration/assets/29168552/7b39e49d-4d11-4be3-b658-116ec18ca098)

Also comes through on events: 
![Screenshot 2024-06-19 at 10 55 42 AM](https://github.com/veracode/github-actions-integration/assets/29168552/b2d98ecc-2eff-466b-a144-4cf81c963dff)
![Screenshot 2024-06-19 at 10 56 14 AM](https://github.com/veracode/github-actions-integration/assets/29168552/58c92e61-2743-46e2-9d56-d51df8b2dd1d)
