### PR TITLE
Update veracode-default-build.yml

### DIFF
--- a/.github/workflows/veracode-default-build.yml
+++ b/.github/workflows/veracode-default-build.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: veracode/scm-packaging:latest
+      image: veracode/scm-packaging:2.0.0
     env:
       VERACODE_API_KEY_ID: '${{ secrets.VERACODE_API_ID }}'
       VERACODE_API_KEY_SECRET: '${{ secrets.VERACODE_API_KEY }}'


### PR DESCRIPTION
Pointing to new docker image with .Net 6,7, & 8 support