### PR TITLE
REPO-763, REPO-769 increase policy scan timeout and fix rerun

### DIFF
--- a/.github/workflows/veracode-policy-scan.yml
+++ b/.github/workflows/veracode-policy-scan.yml
@@ -68,6 +68,10 @@ jobs:
           name: veracode-artifact
           path: ./veracode_artifact_directory
 
+      - name: set version
+        run: |
+          echo "VERSION=${{ github.run_id }}-$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
+
       # run the policy scan action
       - name: Veracode Upload and Scan Action Step
         uses: veracode/uploadandscan-action@v0.1.5
@@ -76,12 +80,12 @@ jobs:
           appname: ${{ inputs.profile_name }}
           createprofile: true
           policy: ${{ inputs.policy_name }}
-          version: '${{ github.run_id }}'
+          version: '${{ env.VERSION }}'
           filepath: ./veracode_artifact_directory/
           vid: '${{ secrets.VERACODE_API_ID }}'
           vkey: '${{ secrets.VERACODE_API_KEY }}'
           #scanpollinginterval: 30
-          scantimeout: 15
+          scantimeout: 30
           # include: ${{ inputs.modules_to_scan }}
           failbuild: ${{ inputs.break_build_policy_findings }}
 


### PR DESCRIPTION
**What Changed**

Updated the github-actions-integration repo and changed the policy scan yml configuration to:
* increase the policy scan timeout from 15 to 30 minutes to allow more time for scan completion to ensure the check run provides the results url needed for the UI
* append the datestamp in UTC to the scan name created on the Veracode Platform to support policy scan Re-run

**Proof that it works**

![image](https://github.com/user-attachments/assets/2725d2ff-ffe2-44ff-af09-6f12a2ec9a50)

![image](https://github.com/user-attachments/assets/5581c53b-65ea-4d5c-9691-3f0a6f312d73)

![image](https://github.com/user-attachments/assets/b924e360-59ef-4db2-a084-1ec60d9fb2b6)

![image](https://github.com/user-attachments/assets/d331b2ae-74df-4b94-80a8-5382999e0b1e)

