### PR TITLE
Update binary-ready-veracode-sast-pipeline-scan.yml

### DIFF
--- a/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
+++ b/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
@@ -177,7 +177,7 @@ jobs:
 
   update-checks-status:
     runs-on: ${{ fromJSON(github.event.client_payload.user_config.default_runs_on) }}
-    needs: pipeline_scan
+    needs: [register, pipeline_scan]
     if: always()
     steps:
      - name: Update check

--- a/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
+++ b/.github/workflows/binary-ready-veracode-sast-pipeline-scan.yml
@@ -197,7 +197,7 @@ jobs:
                 success_count=$((success_count + 1))
                 echo '{"status": "completed", "conclusion": "success"}' > payload.txt
               elif [ "$status" = "failure" ]; then
-                if [ "$BREAK_BUILD_ON_ERROR" = "false" && "$BREAK_BUILD_ON_POLICY" = "false" ]; then
+                if [ "$BREAK_BUILD_ON_ERROR" = "false" ] && [ "$BREAK_BUILD_ON_POLICY" = "false" ]; then
                   echo '{"status": "completed", "conclusion": "success"}' > payload.txt
                 else
                   echo '{"status": "completed", "conclusion": "failure"}' > payload.txt


### PR DESCRIPTION
Resolves the following error:
```
/home/runner/work/_temp/0a504abb-16de-4fc8-ac79-150ec702cda9.sh: line 16: [: missing `]'
```

```
Run success_count=0
  success_count=0
  conclusion="failure"
  # Convert JSON string to a proper format for jq processing
  echo '{
    "pipeline_scan": {
      "result": "failure",
      "outputs": {}
    }
  }' | jq -c 'to_entries[]' | while read -r job; do
    status=$(echo "$job" | jq -r '.value.result')
    echo "$status"
    if [ "$status" = "success" ]; then
      success_count=$((success_count + 1))
      echo '{"status": "completed", "conclusion": "success"}' > payload.txt
    elif [ "$status" = "failure" ]; then
      if [ "$BREAK_BUILD_ON_ERROR" = "false" && "$BREAK_BUILD_ON_POLICY" = "false" ]; then
        echo '{"status": "completed", "conclusion": "success"}' > payload.txt
      else
        echo '{"status": "completed", "conclusion": "failure"}' > payload.txt
      fi
    fi
    curl -X PATCH \
      -H "Authorization: ***" \
      -H "Accept: application/vnd.github+json" \
      https://api.github.com/repos/wsandersvco/verademo-java/check-runs/ \
      -d @"payload.txt"
  done
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    BREAK_BUILD_ON_ERROR: false
    BREAK_BUILD_ON_POLICY: true
/home/runner/work/_temp/0a504abb-16de-4fc8-ac79-150ec702cda9.sh: line 16: [: missing `]'
failure
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   154    0   106  100    48    490    222 --:--:-- --:--:-- --:--:--   716
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest",
  "status": "404"
}
```