### PR TITLE
Update veracode-build-dart.yml

### DIFF
--- a/.github/workflows/veracode-build-dart.yml
+++ b/.github/workflows/veracode-build-dart.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v4
       with:
+        distribution: temurin
         java-version: 1.8
 
     - name: Setup Android SDK

--- a/.github/workflows/veracode-code-analysis.yml
+++ b/.github/workflows/veracode-code-analysis.yml
@@ -24,7 +24,7 @@ on:
       - scala-pipeline-scan
       - scala-policy-scan
       - dart-pipeline-scan
-      - dart-policy-sca
+      - dart-policy-scan
       - java-pipeline-scan
       - java-policy-scan
       - unidentified-lang-pipeline-scan


### PR DESCRIPTION
veracode-build-dart.yml encounters an error due to missing required parameter for action/setup-java@v4